### PR TITLE
Empty environment is handled correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.2.1
+
+- [Empty environment is handled correctly](https://github.com/babbel/terraform-aws-lambda-with-inline-code/pull/15)
+
 ## v1.2.0
 
 - [Bump hashicorp/aws dependency](https://github.com/babbel/terraform-aws-lambda-with-inline-code/pull/14)

--- a/main.tf
+++ b/main.tf
@@ -13,7 +13,9 @@ resource "aws_lambda_function" "this" {
   role = aws_iam_role.this.arn
 
   dynamic "environment" {
-    for_each = local.environment_variables != null ? [{ variables = local.environment_variables }] : []
+    // local.environments is built using a merge, and merges always result in a map
+    // so we can safely assume we're dealing with a map here.
+    for_each = length(local.environment_variables) > 0 ? [{ variables = local.environment_variables }] : []
 
     content {
       variables = environment.value.variables


### PR DESCRIPTION
`local.environment_variables` is a merge from:

- `var.environment_variables` (defaults to null)
- `local.secret_environment_variables` (defaults to {})

and even `merge(null, null)` is an empty map.

This should stop passing an empty `environment` attr to `aws_lambda_function` which was introduced with #8.