### PR TITLE
drop deprecated replace_security_groups_on_destroy attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.6.0
+
+- [Drop deprecated replace_security_groups_on_destroy attribute](https://github.com/babbel/terraform-aws-lambda-with-inline-code/pull/28)
+
 ## v1.5.0
 
 - [Relax version constraints for modules](https://github.com/babbel/terraform-aws-lambda-with-inline-code/pull/24)

--- a/main.tf
+++ b/main.tf
@@ -21,8 +21,6 @@ resource "aws_lambda_function" "this" {
     }
   }
 
-  replace_security_groups_on_destroy = var.vpc_config != null ? true : null
-
   dynamic "environment" {
     // local.environments is built using a merge, and merges always result in a map
     // so we can safely assume we're dealing with a map here.


### PR DESCRIPTION
The `replace_security_groups_on_destroy` and `replacement_security_group_ids` attributes are being deprecated as AWS no longer supports this operation. These attributes now have no effect, and will be removed in a future major version.

https://github.com/hashicorp/terraform-provider-aws/issues/31904