### PR TITLE
Add support for resource-specific tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,5 @@ module "lambda" {
   }
 
   source_dir = "lambda/src"
-
-  tags = {
-    app = "example"
-    env = "production"
-  }
 }
 ```

--- a/_test/main.tf
+++ b/_test/main.tf
@@ -20,7 +20,7 @@ module "lambda" {
 
   source_dir = "lambda/src"
 
-  tags = {
+  default_tags = {
     app = "example"
     env = "production"
   }

--- a/_test/main.tf
+++ b/_test/main.tf
@@ -3,7 +3,7 @@ provider "aws" {
 }
 
 module "lambda" {
-  source  = "./.."
+  source = "./.."
 
   function_name = "example"
   description   = "This is an example"

--- a/main.tf
+++ b/main.tf
@@ -34,7 +34,7 @@ resource "aws_lambda_function" "this" {
   filename         = try(var.archive_file.output_path, data.archive_file.this[0].output_path)
   source_code_hash = try(var.archive_file.output_base64sha256, data.archive_file.this[0].output_base64sha256)
 
-  tags = var.tags
+  tags = merge(var.default_tags, var.lambda_function_tags)
 
   depends_on = [
     aws_cloudwatch_log_group.this,
@@ -57,7 +57,7 @@ resource "aws_iam_role" "this" {
 
   assume_role_policy = data.aws_iam_policy_document.lambda-assume-role.json
 
-  tags = var.tags
+  tags = merge(var.default_tags, var.iam_role_tags)
 }
 
 data "aws_iam_policy_document" "lambda-assume-role" {
@@ -84,7 +84,7 @@ resource "aws_cloudwatch_log_group" "this" {
 
   retention_in_days = var.cloudwatch_log_group_retention_in_days
 
-  tags = var.tags
+  tags = merge(var.default_tags, var.cloudwatch_log_group_tags)
 }
 
 data "aws_iam_policy_document" "cloudwatch-log-group" {
@@ -116,7 +116,7 @@ resource "aws_security_group" "this" {
 
   tags = merge({
     Name = "Lambda: ${var.function_name}"
-  }, var.tags)
+  }, var.default_tags, var.security_group_tags)
 
   lifecycle {
     create_before_destroy = true

--- a/variables.tf
+++ b/variables.tf
@@ -5,64 +5,120 @@ variable "archive_file" {
   })
   default = null
 
-  description = "An instance of the `archive_file` data source containing the code of the Lambda function. Conflicts with `source_dir`."
+  description = <<EOS
+An instance of the `archive_file` data source containing the code of the Lambda function. Conflicts with `source_dir`.
+EOS
 }
 
 variable "cloudwatch_log_group_retention_in_days" {
   type    = number
   default = 3
 
-  description = "The number of days to retain the log of the Lambda function."
+  description = <<EOS
+The number of days to retain the log of the Lambda function.
+EOS
+}
+
+variable "cloudwatch_log_group_tags" {
+  type    = map(string)
+  default = {}
+
+  description = <<EOS
+Map of tags assigned to the CloudWatch Logs group used by the Lambda function.
+EOS
+}
+
+variable "default_tags" {
+  type    = map(string)
+  default = {}
+
+  description = <<EOS
+Map of tags assigned to all AWS resources created by this module.
+EOS
 }
 
 variable "description" {
   type = string
 
-  description = "Description of the Lambda function."
+  description = <<EOS
+Description of the Lambda function.
+EOS
 }
 
 variable "environment_variables" {
   type    = map(string)
   default = null
 
-  description = "Environment variable key-value pairs."
+  description = <<EOS
+Environment variable key-value pairs.
+EOS
 }
 
 variable "function_name" {
   type = string
 
-  description = "Name of the Lambda function."
+  description = <<EOS
+Name of the Lambda function.
+EOS
 }
 
 variable "handler" {
   type = string
 
-  description = "The name of the method within your code that Lambda calls to execute your function."
+  description = <<EOS
+The name of the method within your code that Lambda calls to execute your function.
+EOS
+}
+
+variable "iam_role_tags" {
+  type    = map(string)
+  default = {}
+
+  description = <<EOS
+Map of tags assigned to the IAM role of the Lambda function.
+EOS
+}
+
+variable "lambda_function_tags" {
+  type    = map(string)
+  default = {}
+
+  description = <<EOS
+Map of tags assigned to the Lambda function.
+EOS
 }
 
 variable "layers" {
   type    = list(string)
   default = []
 
-  description = "List of up to five Lambda layer ARNs."
+  description = <<EOS
+List of up to five Lambda layer ARNs.
+EOS
 }
 
 variable "memory_size" {
   type = number
 
-  description = "The amount of memory (in MB) available to the function at runtime. Increasing the Lambda function memory also increases its CPU allocation."
+  description = <<EOS
+The amount of memory (in MB) available to the function at runtime. Increasing the Lambda function memory also increases its CPU allocation.
+EOS
 }
 
 variable "reserved_concurrent_executions" {
   type = number
 
-  description = "The number of simultaneous executions to reserve for the Lambda function."
+  description = <<EOS
+The number of simultaneous executions to reserve for the Lambda function.
+EOS
 }
 
 variable "runtime" {
   type = string
 
-  description = "The identifier of the Lambda function [runtime](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html)."
+  description = <<EOS
+The identifier of the Lambda function [runtime](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html).
+EOS
 }
 
 variable "secret_environment_variables" {
@@ -78,24 +134,30 @@ Permission will be added allowing the Lambda function to read the secret values.
 EOS
 }
 
+variable "security_group_tags" {
+  type    = map(string)
+  default = {}
+
+  description = <<EOS
+Map of tags assigned to the security group of the Lambda function (if it is placed into a VPC).
+EOS
+}
+
 variable "source_dir" {
   type    = string
   default = null
 
-  description = "Path of the directory which shall be packed as code of the Lambda function. Conflicts with `archive_file`."
-}
-
-variable "tags" {
-  type    = map(string)
-  default = {}
-
-  description = "Tags which will be assigned to all resources."
+  description = <<EOS
+Path of the directory which shall be packed as code of the Lambda function. Conflicts with `archive_file`.
+EOS
 }
 
 variable "timeout" {
   type = number
 
-  description = "The amount of time (in seconds) per execution before stopping it."
+  description = <<EOS
+The amount of time (in seconds) per execution before stopping it.
+EOS
 }
 
 variable "vpc_config" {
@@ -111,7 +173,6 @@ variable "vpc_config" {
       id = string
     })
   })
-
   default = null
 
   description = <<EOS


### PR DESCRIPTION
Breaking change: Renaming `var.tags` to `var.default_tag` in order to make it clearer that those are tags are applied to all AWS resources.