### PR TITLE
Breaking change: Rename `var.tags` to `var.default_tags`

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,5 @@ module "lambda" {
   }
 
   source_dir = "lambda/src"
-
-  tags = {
-    app = "example"
-    env = "production"
-  }
 }
 ```

--- a/_test/main.tf
+++ b/_test/main.tf
@@ -20,7 +20,7 @@ module "lambda" {
 
   source_dir = "lambda/src"
 
-  tags = {
+  default_tags = {
     app = "example"
     env = "production"
   }

--- a/main.tf
+++ b/main.tf
@@ -34,7 +34,7 @@ resource "aws_lambda_function" "this" {
   filename         = try(var.archive_file.output_path, data.archive_file.this[0].output_path)
   source_code_hash = try(var.archive_file.output_base64sha256, data.archive_file.this[0].output_base64sha256)
 
-  tags = var.tags
+  tags = var.default_tags
 
   depends_on = [
     aws_cloudwatch_log_group.this,
@@ -57,7 +57,7 @@ resource "aws_iam_role" "this" {
 
   assume_role_policy = data.aws_iam_policy_document.lambda-assume-role.json
 
-  tags = var.tags
+  tags = var.default_tags
 }
 
 data "aws_iam_policy_document" "lambda-assume-role" {
@@ -84,7 +84,7 @@ resource "aws_cloudwatch_log_group" "this" {
 
   retention_in_days = var.cloudwatch_log_group_retention_in_days
 
-  tags = var.tags
+  tags = var.default_tags
 }
 
 data "aws_iam_policy_document" "cloudwatch-log-group" {
@@ -116,7 +116,7 @@ resource "aws_security_group" "this" {
 
   tags = merge({
     Name = "Lambda: ${var.function_name}"
-  }, var.tags)
+  }, var.default_tags)
 
   lifecycle {
     create_before_destroy = true

--- a/variables.tf
+++ b/variables.tf
@@ -19,6 +19,15 @@ The number of days to retain the log of the Lambda function.
 EOS
 }
 
+variable "default_tags" {
+  type    = map(string)
+  default = {}
+
+  description = <<EOS
+Map of tags assigned to all AWS resources created by this module.
+EOS
+}
+
 variable "description" {
   type = string
 
@@ -104,15 +113,6 @@ variable "source_dir" {
 
   description = <<EOS
 Path of the directory which shall be packed as code of the Lambda function. Conflicts with `archive_file`.
-EOS
-}
-
-variable "tags" {
-  type    = map(string)
-  default = {}
-
-  description = <<EOS
-Map of tags assigned to all AWS resources created by this module.
 EOS
 }
 


### PR DESCRIPTION
This change is done to make it more clear, that tags specified via this attribute will be assigned to all AWS resources created by this module.

Also drop this attribute from the usage example in the `README.md`, as this attribute is rather for edge cases, as default tags typically specified via the `default_tags` block of the AWS provider.